### PR TITLE
Fixed broken layout after chesscom class changed on /analysis

### DIFF
--- a/src/chesscom.js
+++ b/src/chesscom.js
@@ -61,7 +61,7 @@ const onMutation = () => {
         element = document.getElementsByClassName('quick-analysis-buttons')[0];
     }
     if (element == null) {
-        element = document.getElementsByClassName('game-controls-primary-component')[0];
+        element = document.getElementsByClassName('game-controls-view-component')[0];
     }
 
     if (element) {


### PR DESCRIPTION
The flex button was breaking layout inside the primary div at the /analysis page because it has some other controls button inside, so I've changed our button position